### PR TITLE
Split toy script into components and test them

### DIFF
--- a/src/codons.py
+++ b/src/codons.py
@@ -1,0 +1,95 @@
+
+_UNKNOWN_AMINO = '?'
+
+encodings = {
+    'AAA': 'K',
+    'AAC': 'N',
+    'AAG': 'K',
+    'AAT': 'N',
+    'ACA': 'T',
+    'ACC': 'T',
+    'ACG': 'T',
+    'ACT': 'T',
+    'AGA': 'R',
+    'AGC': 'S',
+    'AGG': 'R',
+    'AGT': 'S',
+    'ATA': 'I',
+    'ATC': 'I',
+    'ATG': 'M',
+    'ATT': 'I',
+    'CAA': 'Q',
+    'CAC': 'H',
+    'CAG': 'Q',
+    'CAT': 'H',
+    'CCA': 'P',
+    'CCC': 'P',
+    'CCG': 'P',
+    'CCT': 'P',
+    'CGA': 'R',
+    'CGC': 'R',
+    'CGG': 'R',
+    'CGT': 'R',
+    'CTA': 'L',
+    'CTC': 'L',
+    'CTG': 'L',
+    'CTT': 'L',
+    'GAA': 'E',
+    'GAC': 'D',
+    'GAG': 'E',
+    'GAT': 'D',
+    'GCA': 'A',
+    'GCC': 'A',
+    'GCG': 'A',
+    'GCT': 'A',
+    'GGA': 'G',
+    'GGC': 'G',
+    'GGG': 'G',
+    'GGT': 'G',
+    'GTA': 'V',
+    'GTC': 'V',
+    'GTG': 'V',
+    'GTT': 'V',
+    'TAA': 'Ochre',  # Use a matching symbol to make stops interchangeable
+    'TAC': 'Y',
+    'TAG': 'Amber',  # Use a matching symbol to make stops interchangeable
+    'TAT': 'Y',
+    'TCA': 'S',
+    'TCC': 'S',
+    'TCG': 'S',
+    'TCT': 'S',
+    'TGA': 'Opal',  # Use a matching symbol to make stops interchangeable
+    'TGC': 'C',
+    'TGG': 'W',
+    'TGT': 'C',
+    'TTA': 'L',
+    'TTC': 'F',
+    'TTG': 'L',
+    'TTT': 'F',
+}
+
+
+class Codon(object):
+    def __init__(self, bases):
+        assert len(bases) == 3, 'codons must have length 3!'
+        bases = bases.upper()
+        for base in bases:
+            assert base in 'ACGT_', 'unrecognized base "{}"'.format(base)
+        self.bases = bases
+
+    def __eq__(self, other):
+        return self.bases == other.bases
+
+    def get_amino(self):
+        if self.bases in encodings.keys():
+            return encodings[self.bases]
+        else:
+            return _UNKNOWN_AMINO
+
+    def encodes_same_amino(self, other):
+        this_amino = self.get_amino()
+        if this_amino == _UNKNOWN_AMINO:
+            # unmapped codons must match exactly
+            return self.bases == other.bases
+
+        return self.get_amino() == other.get_amino()

--- a/src/codons.py
+++ b/src/codons.py
@@ -70,7 +70,18 @@ encodings = {
 
 
 class Codon(object):
+    """
+    A codon consists of three DNA bases, and may be associated with an amino
+    # acid. (All codons consisting exclusively of bases ACGT map to an amino or
+    stop.)
+    """
     def __init__(self, bases):
+        """
+        :param bases: Any length-three string of [ACGT_] (case-insensitive),
+            where ACGT are nucleic acids and _ represents a missing base (*not*
+            a wildcard; generally used to align the ends of a larger sequence
+            that doesn't end with a complete codon).
+        """
         assert len(bases) == 3, 'codons must have length 3!'
         bases = bases.upper()
         for base in bases:
@@ -78,15 +89,34 @@ class Codon(object):
         self.bases = bases
 
     def __eq__(self, other):
+        """Returns true if two codons have identical bases in the same order."""
         return self.bases == other.bases
 
     def get_amino(self):
+        """
+        Returns the string representation of an amino. Typically a
+        single-character, except for stop codons. Can return a placeholder for
+        an unknown amino in ambiguous cases. (See _UNKNOWN_AMINO)
+
+        :return: string representation of the encoded amino acid.
+        """
         if self.bases in encodings.keys():
             return encodings[self.bases]
         else:
             return _UNKNOWN_AMINO
 
     def encodes_same_amino(self, other):
+        """
+        Whether two codons encode for the same amino acid.
+
+        Note: '_' is *not* a wildcard. A codon containing this placeholder is
+        only considered to amino-match identical codons.
+        (e.g. __C encodes the 'same' amino as __C, but not __T, even though this
+        substitution would yield the same amino for any specific prefix.)
+
+        :param other: another codon
+        :return: boolean
+        """
         this_amino = self.get_amino()
         if this_amino == _UNKNOWN_AMINO:
             # unmapped codons must match exactly

--- a/src/main.py
+++ b/src/main.py
@@ -1,200 +1,27 @@
-"""
-Author: Brandon Patterson
+from sequence import Sequence
+from wobble_cut_detector import WobbleCutDetector
+import restriction_enzymes as enzymes
 
-A self-contained toy script for determining possible cuts of a nucleotide
-sequence, including potential wobble-enabled cuts.
-"""
 
 # Must be properly aligned. (Use leading underscores to align first codon.)
 sequence_of_interest = 'AGTGGCTCCTAGAGGCTCGAATCAGCTATC'
 
-# TODO: update enzymes based on ~availability
-# Sorting by preference will list common enzymes first in results
-restriction_enzymes = {
-    'AciI': 'CCGC',
-    'AluI': 'AGCT',
-    'BamHI': 'GGATCC',
-    'EcoRI': 'GAATTC',
-    'EcoRV': 'GATATC',
-    'HaeIII': 'GGCC',
-    'HgaI': 'GACGC',
-    'HindIII': 'AAGCTT',
-    'KpnI': 'GGTACC',
-    'NotI': 'GCGGCCGC',
-    'PstI': 'CTGCAG',
-    'PvuII': 'CAGCTG',
-    'SacI': 'GAGCTC',
-    'SalI': 'GTCGAC',
-    'Sau3AI': 'GATC',
-    'ScaI': 'AGTACT',
-    'SmaI': 'CCCGGG',
-    'SpeI': 'ACTAGT',
-    'SphI': 'GCATGC',
-    'StuI': 'AGGCCT',
-    'TaqI': 'TCGA',
-    'XbaI': 'TCTAGA',
-}
-
-# TODO: double check these, they were copied manually...
-codons = {
-    'AAA': 'K',
-    'AAC': 'N',
-    'AAG': 'K',
-    'AAT': 'N',
-    'ACA': 'T',
-    'ACC': 'T',
-    'ACG': 'T',
-    'ACT': 'T',
-    'AGA': 'R',
-    'AGC': 'S',
-    'AGG': 'R',
-    'AGT': 'S',
-    'ATA': 'I',
-    'ATC': 'I',
-    'ATG': 'M',
-    'ATT': 'I',
-    'CAA': 'Q',
-    'CAC': 'H',
-    'CAG': 'Q',
-    'CAT': 'H',
-    'CCA': 'P',
-    'CCC': 'P',
-    'CCG': 'P',
-    'CCT': 'P',
-    'CGA': 'R',
-    'CGC': 'R',
-    'CGG': 'R',
-    'CGT': 'R',
-    'CTA': 'L',
-    'CTC': 'L',
-    'CTG': 'L',
-    'CTT': 'L',
-    'GAA': 'E',
-    'GAC': 'D',
-    'GAG': 'E',
-    'GAT': 'D',
-    'GCA': 'A',
-    'GCC': 'A',
-    'GCG': 'A',
-    'GCT': 'A',
-    'GGA': 'G',
-    'GGC': 'G',
-    'GGG': 'G',
-    'GGT': 'G',
-    'GTA': 'V',
-    'GTC': 'V',
-    'GTG': 'V',
-    'GTT': 'V',
-    'TAA': 'Ochre',  # Use a matching symbol to make stops interchangeable
-    'TAC': 'Y',
-    'TAG': 'Amber',  # Use a matching symbol to make stops interchangeable
-    'TAT': 'Y',
-    'TCA': 'S',
-    'TCC': 'S',
-    'TCG': 'S',
-    'TCT': 'S',
-    'TGA': 'Opal',  # Use a matching symbol to make stops interchangeable
-    'TGC': 'C',
-    'TGG': 'W',
-    'TGT': 'C',
-    'TTA': 'L',
-    'TTC': 'F',
-    'TTG': 'L',
-    'TTT': 'F',
-}
-
-
-def equivalent_codons(codon_one, codon_two):
-    """
-    Returns True if two codons are guaranteed to code the same amino.
-    ('_' represents an unknown amino)
-    """
-    if codon_one == codon_two:
-        return True
-    if '_' in codon_one or '_' in codon_two:
-        # TODO: consider optimizing (e.g. __T and __C *are* equivalent)
-        return False
-    return codons[codon_one] == codons[codon_two]
-
-
-def equivalent_sequences(seq_one, seq_two):
-    """
-    Returns True if two codon sequences code for the same amino sequence.
-    ('_' represents an unknown amino)
-    """
-    if len(seq_one) != len(seq_two):
-        return False
-
-    assert (len(seq_one) % 3 == 0)
-
-    # for codon in seq
-    for i in range(0, len(seq_one), 3):
-        if not equivalent_codons(seq_one[i:i + 3], seq_two[i:i + 3]):
-            return False
-
-    return True
-
-
-def invert(seq):
-    """
-    Inverts a DNA sequence by flipping each base and reversing the sequence
-    (CAT -> ATG)
-    """
-    return seq.replace('A', 't').replace('T', 'a').replace('C', 'g') \
-               .replace('G', 'c').upper()[::-1]
-
-
-def get_edit(seq_from, seq_to):
-    """
-    Returns the 'edit' sequence needed to convert seq_from to seq_to.
-    For example, get_edit('ATGGTC', 'ATCGAC') returns 'ATcGaC'
-    """
-    assert (len(seq_from) == len(seq_to))
-
-    edit = ''
-    for i in range(len(seq_from)):
-        if seq_from[i] == seq_to[i]:
-            edit += seq_to[i]
-        else:
-            edit += seq_to[i].lower()
-
-    return edit
-
-
-def detect_wobble_cuts(seq, cut_seq):
-    """
-    Returns a list of location/edit pairs that will enable a cut_seq match.
-    An 'edit' is a copy of the cut sequence with altered aminos in lowercase.
-    """
-    edit_list = []
-    cut_set = set()
-    cut_set.add(cut_seq)
-    cut_set.add(invert(cut_seq))
-    for pattern in cut_set:
-        for i in range(len(seq) - len(pattern) + 1):
-            seq_edit = seq[:i] + pattern + seq[i + len(pattern):]
-            # TODO: compare relevant portions of sequence to improve performance
-            if equivalent_sequences(seq, seq_edit):
-                edit = get_edit(seq[i:i + len(pattern)], pattern)
-                edit_list.append((i, edit))
-    return edit_list
-
 
 if __name__ == '__main__':
-    print('Checking sequence for potential cuts...')
-    print(sequence_of_interest)
+    aligned_seq = Sequence(sequence_of_interest).align()
+    print('original sequence: {}'.format(aligned_seq.bases))
+    print('original amino chain: {}'.format(aligned_seq.get_amino_string()))
+    print()
+    print('Checking sequence for potential cuts (leaving aminos unchanged)...')
     print()
 
-    # pad sequence to a full frame
-    padded_sequence = sequence_of_interest
-    while len(padded_sequence) % 3 != 0:
-        padded_sequence += '_'
+    wobbler = WobbleCutDetector()
 
-    for name, cut_pattern in restriction_enzymes.items():
-        wobble_cuts = detect_wobble_cuts(padded_sequence, cut_pattern)
+    for enzyme in enzymes.get_all_enzymes():
+        wobble_cuts = wobbler.detect_cuts(aligned_seq, enzyme)
         if len(wobble_cuts) > 0:
-            print('possible cuts for {}:'.format(name))
-            for cut in wobble_cuts:
-                print('  index: {}  edit: {}'.format(cut[0], cut[1]))
+            print('possible cuts for {}:'.format(enzyme.name))
+            for cut_edit in wobble_cuts:
+                print('  {}'.format(cut_edit))
 
             print()

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
+"""
+A utility that searches for possible restriction enzyme cut-sites in a DNA
+sequence, allowing for base substitutions (provided that the resulting amino
+acid chain remains unaltered.
+"""
+
 from sequence import Sequence
 from wobble_cut_detector import WobbleCutDetector
 import restriction_enzymes as enzymes
 
-
-# Must be properly aligned. (Use leading underscores to align first codon.)
+# Must be properly left-aligned. (Use leading underscores to align first codon.)
 sequence_of_interest = 'AGTGGCTCCTAGAGGCTCGAATCAGCTATC'
-
 
 if __name__ == '__main__':
     aligned_seq = Sequence(sequence_of_interest).align()

--- a/src/restriction_enzymes.py
+++ b/src/restriction_enzymes.py
@@ -2,15 +2,39 @@ from sequence import Sequence
 
 
 class RestrictionEnzyme(object):
+    """
+    A restriction enzyme, which will cut any DNA sequence matching a pattern.
+    """
+
     def __init__(self, name, base_sequence):
+        """
+        :param name: the name of the enzyme
+        :param base_sequence: a string of bases ACGT (of any length)
+        """
+        # Check that bases are valid
+        for base in base_sequence:
+            assert base in 'ACGT', 'unsupported restriction enzyme base "{}"' \
+                .format(base)
+
         self.name = name
         self.sequence = Sequence(base_sequence)
 
     def __len__(self):
+        """The number of bases in the match pattern."""
         return len(self.sequence)
 
     def is_symmetric(self):
-        return self.sequence == self.sequence.invert()
+        """
+        Whether the enzyme's match pattern is its own reverse complement.
+
+        Examples:
+            AATT -> True
+            GGTACC -> True
+            GCCG -> False
+
+        :return: boolean
+        """
+        return self.sequence == self.sequence.reverse_complement()
 
 
 _enzymes = [
@@ -40,4 +64,7 @@ _enzymes = [
 
 
 def get_all_enzymes():
+    """
+    :return: a list of 'default' configured restriction enzymes
+    """
     return _enzymes.copy()

--- a/src/restriction_enzymes.py
+++ b/src/restriction_enzymes.py
@@ -1,0 +1,43 @@
+from sequence import Sequence
+
+
+class RestrictionEnzyme(object):
+    def __init__(self, name, base_sequence):
+        self.name = name
+        self.sequence = Sequence(base_sequence)
+
+    def __len__(self):
+        return len(self.sequence)
+
+    def is_symmetric(self):
+        return self.sequence == self.sequence.invert()
+
+
+_enzymes = [
+    RestrictionEnzyme('AciI', 'CCGC'),
+    RestrictionEnzyme('AluI', 'AGCT'),
+    RestrictionEnzyme('BamHI', 'GGATCC'),
+    RestrictionEnzyme('EcoRI', 'GAATTC'),
+    RestrictionEnzyme('EcoRV', 'GATATC'),
+    RestrictionEnzyme('HaeIII', 'GGCC'),
+    RestrictionEnzyme('HgaI', 'GACGC'),
+    RestrictionEnzyme('HindIII', 'AAGCTT'),
+    RestrictionEnzyme('KpnI', 'GGTACC'),
+    RestrictionEnzyme('NotI', 'GCGGCCGC'),
+    RestrictionEnzyme('PstI', 'CTGCAG'),
+    RestrictionEnzyme('PvuII', 'CAGCTG'),
+    RestrictionEnzyme('SacI', 'GAGCTC'),
+    RestrictionEnzyme('SalI', 'GTCGAC'),
+    RestrictionEnzyme('Sau3AI', 'GATC'),
+    RestrictionEnzyme('ScaI', 'AGTACT'),
+    RestrictionEnzyme('SmaI', 'CCCGGG'),
+    RestrictionEnzyme('SpeI', 'ACTAGT'),
+    RestrictionEnzyme('SphI', 'GCATGC'),
+    RestrictionEnzyme('StuI', 'AGGCCT'),
+    RestrictionEnzyme('TaqI', 'TCGA'),
+    RestrictionEnzyme('XbaI', 'TCTAGA'),
+]
+
+
+def get_all_enzymes():
+    return _enzymes.copy()

--- a/src/sequence.py
+++ b/src/sequence.py
@@ -2,7 +2,13 @@ from codons import Codon
 
 
 class Sequence(object):
+    """A sequence of nucleic acid bases. May be unaligned."""
+
     def __init__(self, base_sequence_str):
+        """
+        :param base_sequence_str: any case-insensitive string of ACGT_
+        """
+
         # Convert to upper
         base_sequence_str = base_sequence_str.upper()
 
@@ -13,21 +19,28 @@ class Sequence(object):
         self.bases = base_sequence_str
 
     def __eq__(self, other):
+        """Whether two Sequences are identical"""
         return self.bases == other.bases
 
     def __len__(self):
+        """The number of bases in the Sequence"""
         return len(self.bases)
 
     def align(self):
+        """
+        :return: AlignedSequence obtained by right-padding the Sequence with _'s
+        """
         bases_copy = self.bases
         while len(bases_copy) % 3 != 0:
             bases_copy += '_'
         return AlignedSequence(bases_copy)
 
-    def invert(self):
+    def reverse_complement(self):
         """
-        Inverts a DNA sequence by flipping each base and reversing the sequence
-        (CAT -> ATG)
+        Inverts a DNA sequence by flipping each base and reversing the sequence.
+        Example: CAT -> ATG
+
+        :returns: the reverse complement Sequence
         """
         return Sequence(self.bases
                         .replace('A', 't')
@@ -39,7 +52,15 @@ class Sequence(object):
 
 
 class AlignedSequence(Sequence):
+    """
+    A Sequence composed of complete, aligned codons.
+    Can be translated into a chain of amino acids.
+    """
+
     def __init__(self, base_sequence):
+        """
+        :param base_sequence: case-insensitive string of ACGT_, with length 3n
+        """
         super().__init__(base_sequence)
 
         # assert that aligned sequence has proper length
@@ -49,13 +70,20 @@ class AlignedSequence(Sequence):
         self.codons = []
 
         for i in range(0, len(base_sequence), 3):
-            codon = Codon(base_sequence[i:i+3])
+            codon = Codon(base_sequence[i:i + 3])
             self.codons.append(codon)
 
     def get_amino_string(self):
+        """
+        :return: string representation of the AlignedSequence's amino chain
+        """
         return ''.join(list(map(lambda c: c.get_amino(), self.codons)))
 
     def encodes_same_aminos(self, other):
+        """
+        :param other: AlignedSequence
+        :return: True iff two sequences represent an identical amino acid chain
+        """
         if len(self.codons) != len(other.codons):
             return False
         for left, right in zip(self.codons, other.codons):

--- a/src/sequence.py
+++ b/src/sequence.py
@@ -1,0 +1,64 @@
+from codons import Codon
+
+
+class Sequence(object):
+    def __init__(self, base_sequence_str):
+        # Convert to upper
+        base_sequence_str = base_sequence_str.upper()
+
+        # Check that bases are valid
+        for base in base_sequence_str:
+            assert base in 'ACGT_', 'unrecognized base "{}"'.format(base)
+
+        self.bases = base_sequence_str
+
+    def __eq__(self, other):
+        return self.bases == other.bases
+
+    def __len__(self):
+        return len(self.bases)
+
+    def align(self):
+        bases_copy = self.bases
+        while len(bases_copy) % 3 != 0:
+            bases_copy += '_'
+        return AlignedSequence(bases_copy)
+
+    def invert(self):
+        """
+        Inverts a DNA sequence by flipping each base and reversing the sequence
+        (CAT -> ATG)
+        """
+        return Sequence(self.bases
+                        .replace('A', 't')
+                        .replace('T', 'a')
+                        .replace('C', 'g')
+                        .replace('G', 'c')
+                        .upper()
+                        [::-1])
+
+
+class AlignedSequence(Sequence):
+    def __init__(self, base_sequence):
+        super().__init__(base_sequence)
+
+        # assert that aligned sequence has proper length
+        assert len(base_sequence) % 3 == 0, \
+            'AlignedSequence with len {}'.format(len(base_sequence))
+
+        self.codons = []
+
+        for i in range(0, len(base_sequence), 3):
+            codon = Codon(base_sequence[i:i+3])
+            self.codons.append(codon)
+
+    def get_amino_string(self):
+        return ''.join(list(map(lambda c: c.get_amino(), self.codons)))
+
+    def encodes_same_aminos(self, other):
+        if len(self.codons) != len(other.codons):
+            return False
+        for left, right in zip(self.codons, other.codons):
+            if not left.encodes_same_amino(right):
+                return False
+        return True

--- a/src/sequence_edit.py
+++ b/src/sequence_edit.py
@@ -1,0 +1,42 @@
+from sequence import AlignedSequence
+
+
+class SequenceReplacementEdit(object):
+    def __init__(self, aligned_sequence, override_sequence, offset):
+        assert offset + len(override_sequence) <= len(aligned_sequence), \
+                'override_sequence doesn\'t fit in aligned_sequence with offset'
+        self._original_sequence = aligned_sequence
+        edited_bases = aligned_sequence.bases[:offset] \
+                + override_sequence.bases \
+                + aligned_sequence.bases[offset+len(override_sequence):]
+        self._new_sequence = AlignedSequence(edited_bases)
+        self._edit_begin = offset
+        # align to codon begin
+        while self._edit_begin % 3 != 0:
+            self._edit_begin -= 1
+        self._edit_end = offset + len(override_sequence) - 1
+        # align to codon end
+        while self._edit_end % 3 != 0:
+            self._edit_end += 1
+
+    def __str__(self):
+        old = self._original_sequence.bases[self._edit_begin:self._edit_end]
+        new = self._new_sequence.bases[self._edit_begin:self._edit_end]
+        edit_str = old + ' -> '
+        for i in range(len(old)):
+            edit_str += new[i] if old[i] == new[i] else new[i].lower()
+
+        return 'index: {}\t{}'.format(self._edit_begin+1, edit_str)
+
+    def number_of_bases_modified(self):
+        old = self._original_sequence.bases[self._edit_begin:self._edit_end]
+        new = self._new_sequence.bases[self._edit_begin:self._edit_end]
+        return sum(old[i] != new[i] for i in range(len(old)))
+
+    def number_of_aminos_modified(self):
+        begin = self._edit_begin // 3
+        end = self._edit_end // 3
+        old = self._original_sequence.codons[begin:end]
+        new = self._new_sequence.codons[begin:end]
+        return sum(not old[i].encodes_same_amino(new[i])
+                   for i in range(len(old)))

--- a/src/sequence_edit.py
+++ b/src/sequence_edit.py
@@ -14,10 +14,14 @@ class SequenceReplacementEdit(object):
         # align to codon begin
         while self._edit_begin % 3 != 0:
             self._edit_begin -= 1
-        self._edit_end = offset + len(override_sequence) - 1
+        self._edit_end = offset + len(override_sequence)
         # align to codon end
         while self._edit_end % 3 != 0:
             self._edit_end += 1
+
+    def __eq__(self, other):
+        return self._original_sequence == other._original_sequence \
+                and self._new_sequence == other._new_sequence
 
     def __str__(self):
         old = self._original_sequence.bases[self._edit_begin:self._edit_end]
@@ -26,7 +30,7 @@ class SequenceReplacementEdit(object):
         for i in range(len(old)):
             edit_str += new[i] if old[i] == new[i] else new[i].lower()
 
-        return 'index: {}\t{}'.format(self._edit_begin+1, edit_str)
+        return 'edit index: {}\t{}'.format(self._edit_begin+1, edit_str)
 
     def number_of_bases_modified(self):
         old = self._original_sequence.bases[self._edit_begin:self._edit_end]

--- a/src/sequence_edit.py
+++ b/src/sequence_edit.py
@@ -2,13 +2,25 @@ from sequence import AlignedSequence
 
 
 class SequenceReplacementEdit(object):
+    """
+    Represents a specific transformation of one one aligned nucleic acid
+    sequence to another using single-base replacements.
+    """
+
     def __init__(self, aligned_sequence, override_sequence, offset):
+        """
+        :param aligned_sequence: an AlignedSequence
+        :param override_sequence: a Sequence of bases to overwrite onto the
+            original sequence. (Bases are not required to differ from original.)
+        :param offset: the zero-based position to start the edit from
+        """
         assert offset + len(override_sequence) <= len(aligned_sequence), \
-                'override_sequence doesn\'t fit in aligned_sequence with offset'
+            'override_sequence doesn\'t fit in aligned_sequence with offset'
         self._original_sequence = aligned_sequence
         edited_bases = aligned_sequence.bases[:offset] \
-                + override_sequence.bases \
-                + aligned_sequence.bases[offset+len(override_sequence):]
+                       + override_sequence.bases \
+                       + aligned_sequence.bases[
+                         offset + len(override_sequence):]
         self._new_sequence = AlignedSequence(edited_bases)
         self._edit_begin = offset
         # align to codon begin
@@ -20,24 +32,35 @@ class SequenceReplacementEdit(object):
             self._edit_end += 1
 
     def __eq__(self, other):
+        """Whether two edits have identical before/after AlignedSequences"""
         return self._original_sequence == other._original_sequence \
-                and self._new_sequence == other._new_sequence
+               and self._new_sequence == other._new_sequence
 
     def __str__(self):
+        """
+        :return: A human-readable summary of the edit opperation
+        """
         old = self._original_sequence.bases[self._edit_begin:self._edit_end]
         new = self._new_sequence.bases[self._edit_begin:self._edit_end]
         edit_str = old + ' -> '
         for i in range(len(old)):
             edit_str += new[i] if old[i] == new[i] else new[i].lower()
 
-        return 'edit index: {}\t{}'.format(self._edit_begin+1, edit_str)
+        return 'edit index: {}\t{}'.format(self._edit_begin + 1, edit_str)
 
     def number_of_bases_modified(self):
+        """
+        :return: The number of bases modified by the edit
+        """
         old = self._original_sequence.bases[self._edit_begin:self._edit_end]
         new = self._new_sequence.bases[self._edit_begin:self._edit_end]
         return sum(old[i] != new[i] for i in range(len(old)))
 
     def number_of_aminos_modified(self):
+        """
+        :return: The number of amino acids modified by the edit
+            (Not all base-edits produce amino changes)
+        """
         begin = self._edit_begin // 3
         end = self._edit_end // 3
         old = self._original_sequence.codons[begin:end]

--- a/src/test_codons.py
+++ b/src/test_codons.py
@@ -1,0 +1,64 @@
+from codons import Codon
+import codons
+import unittest
+
+
+class TestCodon(unittest.TestCase):
+    def test_init_enforces_length(self):
+        self.assertRaises(AssertionError, lambda: Codon(''))
+        self.assertRaises(AssertionError, lambda: Codon('A'))
+        self.assertRaises(AssertionError, lambda: Codon('AA'))
+        self.assertRaises(AssertionError, lambda: Codon('AAAA'))
+        self.assertRaises(AssertionError, lambda: Codon('AAAAA'))
+
+    def test_init_is_case_insensitive(self):
+        self.assertEqual(Codon('AGT'), Codon('agt'))
+
+    def test_init_validates_bases(self):
+        # These are all valid
+        Codon('AAA')
+        Codon('CCC')
+        Codon('GGG')
+        Codon('TTT')
+        Codon('___')  # unknown/placeholder
+
+        # These are all invalid
+        self.assertRaises(AssertionError, lambda: Codon('UUU'))
+        self.assertRaises(AssertionError, lambda: Codon('BBB'))
+        self.assertRaises(AssertionError, lambda: Codon('XXX'))
+        self.assertRaises(AssertionError, lambda: Codon('***'))
+        self.assertRaises(AssertionError, lambda: Codon('5\'AAA'))
+        self.assertRaises(AssertionError, lambda: Codon('3\'AAA'))
+        self.assertRaises(AssertionError, lambda: Codon('UUU'))
+
+    def test_eq(self):
+        self.assertEqual(Codon('AAA'), Codon('AAA'))
+        self.assertNotEqual(Codon('AAA'), Codon('AAG'))
+        self.assertEqual(Codon('__T'), Codon('__T'))
+        self.assertNotEqual(Codon('AAT'), Codon('__C'))
+        self.assertNotEqual(Codon('__T'), Codon('__C'))
+
+    def test_get_amino(self):
+        self.assertEqual(Codon('AAA').get_amino(), 'K')
+        self.assertEqual(Codon('CAT').get_amino(), 'H')
+        self.assertEqual(Codon('TAA').get_amino(), 'Ochre')
+        self.assertEqual(Codon('___').get_amino(), codons._UNKNOWN_AMINO)
+        self.assertEqual(Codon('_AA').get_amino(), codons._UNKNOWN_AMINO)
+        self.assertEqual(Codon('AC_').get_amino(), codons._UNKNOWN_AMINO)
+
+    def test_encodes_same_amino(self):
+        self.assertTrue(Codon('AAA').encodes_same_amino(Codon('AAG')))
+        self.assertTrue(Codon('CTA').encodes_same_amino(Codon('TTG')))
+
+        # We consider stop codons distinct (optional)
+        self.assertFalse(Codon('TAA').encodes_same_amino(Codon('TAG')))
+
+        # '_' is considered a 'missing' base, and maps to an 'UNKNOWN' codon
+        self.assertTrue(Codon('TC_').encodes_same_amino(Codon('TC_')))
+        self.assertTrue(Codon('__A').encodes_same_amino(Codon('__A')))
+        # Note that '_' is *not* a wildcard. (TCN all map to the same amino)
+        self.assertFalse(Codon('TC_').encodes_same_amino(Codon('TCA')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_restriction_enzymes.py
+++ b/src/test_restriction_enzymes.py
@@ -10,6 +10,9 @@ class TestRestrictionEnzyme(unittest.TestCase):
         self.assertEqual(enzyme.name, 'aName')
         self.assertEqual(enzyme.sequence, Sequence('CATG'))
 
+    def test_init_validates_bases(self):
+        self.assertRaises(AssertionError, lambda: RestrictionEnzyme('x', 'ABA'))
+
     def test_len(self):
         self.assertEqual(len(RestrictionEnzyme('x', 'CATG')), 4)
         self.assertEqual(len(RestrictionEnzyme('x', 'GCATGC')), 6)

--- a/src/test_restriction_enzymes.py
+++ b/src/test_restriction_enzymes.py
@@ -1,0 +1,31 @@
+from restriction_enzymes import RestrictionEnzyme
+from sequence import Sequence
+import restriction_enzymes
+import unittest
+
+
+class TestRestrictionEnzyme(unittest.TestCase):
+    def test_init(self):
+        enzyme = RestrictionEnzyme('aName', 'CATG')
+        self.assertEqual(enzyme.name, 'aName')
+        self.assertEqual(enzyme.sequence, Sequence('CATG'))
+
+    def test_len(self):
+        self.assertEqual(len(RestrictionEnzyme('x', 'CATG')), 4)
+        self.assertEqual(len(RestrictionEnzyme('x', 'GCATGC')), 6)
+
+    def test_is_symmetric(self):
+        self.assertTrue(RestrictionEnzyme('x', 'CATG').is_symmetric())
+        self.assertFalse(RestrictionEnzyme('x', 'CTTG').is_symmetric())
+
+
+class TestAllEnzymes(unittest.TestCase):
+    def test_returns_a_copy(self):
+        first = restriction_enzymes.get_all_enzymes()
+        second = restriction_enzymes.get_all_enzymes()
+        self.assertEqual(first, second)
+        self.assertTrue(first is not second)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_sequence.py
+++ b/src/test_sequence.py
@@ -1,0 +1,54 @@
+from codons import Codon
+from sequence import AlignedSequence
+from sequence import Sequence
+import unittest
+
+class TestSequence(unittest.TestCase):
+    def test_init_validates_bases(self):
+        self.assertRaises(AssertionError, lambda: Sequence('XYZ'))
+        self.assertRaises(AssertionError, lambda: Sequence('BBB'))
+        # Valid
+        Sequence('_ACTG')
+
+    def test_init_is_case_insensitive(self):
+        self.assertEqual(Sequence('AGTC'), Sequence('agtc'))
+
+    def test_eq(self):
+        self.assertEqual(Sequence('ACT'), Sequence('ACT'))
+        self.assertNotEqual(Sequence('ACT'), Sequence('CAT'))
+        self.assertNotEqual(Sequence('AAA'), Sequence('AAAA'))
+
+    def test_len(self):
+        self.assertEqual(len(Sequence('ACT')), 3)
+        self.assertEqual(len(Sequence('CATG')), 4)
+
+    def test_invert(self):
+        self.assertEqual(Sequence('ACTG_').invert(), Sequence('_CAGT'))
+
+    def test_align_pads_missing_bases(self):
+        self.assertEqual(Sequence('ACTA').align(), AlignedSequence('ACTA__'))
+
+
+class TestAlignedSequence(unittest.TestCase):
+    def test_init_validates_length(self):
+        self.assertRaises(AssertionError, lambda: AlignedSequence('AA'))
+        self.assertRaises(AssertionError, lambda: AlignedSequence('AAAA'))
+
+    def test_init_populates_codons(self):
+        seq = AlignedSequence('ACTGGC')
+        expected_codons = [Codon('ACT'), Codon('GGC')]
+        self.assertEqual(seq.codons, expected_codons)
+
+    def test_get_amino_string(self):
+        self.assertEqual(AlignedSequence('ACTGGCTT_').get_amino_string(), 'TG?')
+
+    def test_encodes_same_aminos(self):
+        seq = AlignedSequence('ACTGGCTT_')
+        matching = AlignedSequence('ACGGGATT_')
+        not_matching = AlignedSequence('AAAGGGCCC')
+        self.assertTrue(seq.encodes_same_aminos(matching))
+        self.assertFalse(seq.encodes_same_aminos(not_matching))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_sequence.py
+++ b/src/test_sequence.py
@@ -3,6 +3,7 @@ from sequence import AlignedSequence
 from sequence import Sequence
 import unittest
 
+
 class TestSequence(unittest.TestCase):
     def test_init_validates_bases(self):
         self.assertRaises(AssertionError, lambda: Sequence('XYZ'))
@@ -22,8 +23,9 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(len(Sequence('ACT')), 3)
         self.assertEqual(len(Sequence('CATG')), 4)
 
-    def test_invert(self):
-        self.assertEqual(Sequence('ACTG_').invert(), Sequence('_CAGT'))
+    def test_reverse_complement(self):
+        self.assertEqual(Sequence('ACTG_').reverse_complement(),
+                         Sequence('_CAGT'))
 
     def test_align_pads_missing_bases(self):
         self.assertEqual(Sequence('ACTA').align(), AlignedSequence('ACTA__'))

--- a/src/test_sequence_edit.py
+++ b/src/test_sequence_edit.py
@@ -1,0 +1,10 @@
+import unittest
+
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(True, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_sequence_edit.py
+++ b/src/test_sequence_edit.py
@@ -1,9 +1,41 @@
+from sequence import AlignedSequence
+from sequence import Sequence
+from sequence_edit import SequenceReplacementEdit
 import unittest
 
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)
+class TestSequenceEdit(unittest.TestCase):
+    def test_init_enforces_lengths(self):
+        aligned_sequence = AlignedSequence('AAACCCGGGTTT')
+        override_sequence = Sequence('AAAA')
+        self.assertRaises(AssertionError, lambda: SequenceReplacementEdit(
+            aligned_sequence, override_sequence, 9))
+
+    def test_eq(self):
+        edit = SequenceReplacementEdit(AlignedSequence('ACT'), Sequence('A'), 2)
+        same = SequenceReplacementEdit(AlignedSequence('ACT'), Sequence('A'), 2)
+        diff = SequenceReplacementEdit(AlignedSequence('ACT'), Sequence('G'), 2)
+        self.assertEqual(edit, same)
+        self.assertNotEqual(edit, diff)
+
+    def test_str(self):
+        aligned_sequence = AlignedSequence('AAACCCGGGTTT')
+        override_sequence = Sequence('AA')
+        edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
+        self.assertEqual(str(edit), 'edit index: 4\tCCCGGG -> CCaaGG')
+
+    def test_number_of_bases_modified(self):
+        aligned_sequence = AlignedSequence('AAACCCGGGTTT')
+        override_sequence = Sequence('AA')
+        edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
+        self.assertEqual(edit.number_of_bases_modified(), 2)
+
+    def test_number_of_amino_modified(self):
+        aligned_sequence = AlignedSequence('AAACCCGGGTTT')
+        override_sequence = Sequence('AA')
+        edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
+        # CCC and CCa both code P
+        self.assertEqual(edit.number_of_aminos_modified(), 1)
 
 
 if __name__ == '__main__':

--- a/src/test_wobble_cut_detector.py
+++ b/src/test_wobble_cut_detector.py
@@ -1,0 +1,10 @@
+import unittest
+
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(True, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_wobble_cut_detector.py
+++ b/src/test_wobble_cut_detector.py
@@ -1,9 +1,47 @@
+from sequence import AlignedSequence
+from sequence_edit import SequenceReplacementEdit
+from restriction_enzymes import RestrictionEnzyme
+from wobble_cut_detector import WobbleCutDetector
 import unittest
 
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)
+class TestWobbleCutDetector(unittest.TestCase):
+    def test_detect_cuts_no_match(self):
+        aligned = AlignedSequence('AAATTT')
+        enzyme = RestrictionEnzyme('enzyme_x', 'GGG')
+        self.assertEqual(WobbleCutDetector().detect_cuts(aligned, enzyme), [])
+
+    def test_detect_cuts_one_match(self):
+        aligned = AlignedSequence('AGCGGCTTT')
+        enzyme = RestrictionEnzyme('enzyme_x', 'GGG')
+        actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
+        expected_cuts = [SequenceReplacementEdit(aligned, enzyme.sequence, 3)]
+        self.assertEqual(actual_cuts, expected_cuts)
+
+    def test_detect_cuts_one_reverse_match(self):
+        aligned = AlignedSequence('AGCGGCTTT')
+        enzyme = RestrictionEnzyme('enzyme_x', 'CCC')
+        actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
+        expected_cuts = [
+            SequenceReplacementEdit(aligned, enzyme.sequence.invert(), 3)]
+        self.assertEqual(actual_cuts, expected_cuts)
+
+    def test_detect_cuts_two_matches(self):
+        aligned = AlignedSequence('AAAGGGTTT')
+        enzyme = RestrictionEnzyme('enzyme_x', 'GGG')
+        actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
+        expected_cuts = [
+            SequenceReplacementEdit(aligned, enzyme.sequence, 2),
+            SequenceReplacementEdit(aligned, enzyme.sequence, 3),
+        ]
+        self.assertEqual(actual_cuts, expected_cuts)
+
+    def test_detect_cuts_palindromes_counted_once(self):
+        aligned = AlignedSequence('AAATTT')
+        enzyme = RestrictionEnzyme('enzyme_x', 'AT')
+        actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
+        expected_cuts = [SequenceReplacementEdit(aligned, enzyme.sequence, 2)]
+        self.assertEqual(actual_cuts, expected_cuts)
 
 
 if __name__ == '__main__':

--- a/src/test_wobble_cut_detector.py
+++ b/src/test_wobble_cut_detector.py
@@ -23,7 +23,8 @@ class TestWobbleCutDetector(unittest.TestCase):
         enzyme = RestrictionEnzyme('enzyme_x', 'CCC')
         actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
         expected_cuts = [
-            SequenceReplacementEdit(aligned, enzyme.sequence.invert(), 3)]
+            SequenceReplacementEdit(
+                aligned, enzyme.sequence.reverse_complement(), 3)]
         self.assertEqual(actual_cuts, expected_cuts)
 
     def test_detect_cuts_two_matches(self):

--- a/src/wobble_cut_detector.py
+++ b/src/wobble_cut_detector.py
@@ -1,0 +1,23 @@
+from sequence_edit import SequenceReplacementEdit
+
+
+class WobbleCutDetector(object):
+    def __init__(self):
+        pass
+
+    def detect_cuts(self, aligned_sequence, restriction_enzyme):
+        edit_list = self._detect_cuts_one_way(
+            aligned_sequence, restriction_enzyme.sequence)
+        if not restriction_enzyme.is_symmetric():
+            edit_list += self._detect_cuts_one_way(
+                aligned_sequence, restriction_enzyme.sequence.invert())
+        return edit_list
+
+    @staticmethod
+    def _detect_cuts_one_way(aligned_sequence, cut_seq):
+        edit_list = []
+        for offset in range(len(aligned_sequence) - len(cut_seq) + 1):
+            edit = SequenceReplacementEdit(aligned_sequence, cut_seq, offset)
+            if edit.number_of_aminos_modified() == 0:
+                edit_list.append(edit)
+        return edit_list

--- a/src/wobble_cut_detector.py
+++ b/src/wobble_cut_detector.py
@@ -2,19 +2,39 @@ from sequence_edit import SequenceReplacementEdit
 
 
 class WobbleCutDetector(object):
+    """Detects wobble-enabled restriction enzyme cuts"""
+
     def __init__(self):
         pass
 
     def detect_cuts(self, aligned_sequence, restriction_enzyme):
+        """
+        Returns a list of potential edits that enable the aligned sequence to
+        be cut by a given restriction enzyme. Includes cuts matching the
+        reverse complement and preexisting cut-sites (e.g. zero-base edits).
+
+        :param aligned_sequence: AlignedSequence
+        :param restriction_enzyme: RestrictionEnzyme
+        :return: List of SequenceReplacementEdit enabling an enzyme cut
+        """
         edit_list = self._detect_cuts_one_way(
             aligned_sequence, restriction_enzyme.sequence)
         if not restriction_enzyme.is_symmetric():
             edit_list += self._detect_cuts_one_way(
-                aligned_sequence, restriction_enzyme.sequence.invert())
+                aligned_sequence,
+                restriction_enzyme.sequence.reverse_complement())
         return edit_list
 
     @staticmethod
     def _detect_cuts_one_way(aligned_sequence, cut_seq):
+        """
+        Helper that detects edit-enabled cut-sites for the given inputs (without
+        considering the reverse complement).
+
+        :param aligned_sequence: AlignedSequence
+        :param cut_seq: Sequence from a RestrictionEnzyme of interest
+        :return: List of SequenceReplacementEdits enabling a cut
+        """
         edit_list = []
         for offset in range(len(aligned_sequence) - len(cut_seq) + 1):
             edit = SequenceReplacementEdit(aligned_sequence, cut_seq, offset)


### PR DESCRIPTION
(Added a few very-low-hanging features with the refactor)

Resolves #3: lowercase inputs no longer crash
Resolves #7: edits now print context about the pre-edit state (AGT ->AGg)
Resolves #8: printed edit indexes are now 1-based
Resolves #9: added reasonably thorough tests for everything but the small driver-shell main.py
Resolves #10: amino acid chain of original input is printed, with a note that it remains unchanged
Resolves #14: optimized edit comparison to only check for amino diffs in potentially altered codons