### PR TITLE
add support for a usage table

### DIFF
--- a/src/codons.py
+++ b/src/codons.py
@@ -3,7 +3,7 @@ import itertools
 
 _UNKNOWN_AMINO = '?'
 
-encodings = {
+_encodings = {
     'AAA': 'K',
     'AAC': 'N',
     'AAG': 'K',
@@ -70,6 +70,75 @@ encodings = {
     'TTT': 'F',
 }
 
+_usage_source = 'Human'
+
+_usage = {
+    'AAA': 3.35,
+    'AAC': 1.76,
+    'AAG': 3.74,
+    'AAT': 2.05,
+    'ACA': 1.64,
+    'ACC': 1.53,
+    'ACG': 0.47,
+    'ACT': 1.42,
+    'AGA': 1.46,
+    'AGC': 1.39,
+    'AGG': 1.04,
+    'AGT': 1.18,
+    'ATA': 0.92,
+    'ATC': 2.06,
+    'ATG': 2.22,
+    'ATT': 2.16,
+    'CAA': 1.30,
+    'CAC': 1.15,
+    'CAG': 3.03,
+    'CAT': 1.17,
+    'CCA': 1.63,
+    'CCC': 1.35,
+    'CCG': 0.47,
+    'CCT': 1.66,
+    'CGA': 0.75,
+    'CGC': 0.79,
+    'CGG': 0.99,
+    'CGT': 0.53,
+    'CTA': 0.83,
+    'CTC': 1.55,
+    'CTG': 3.32,
+    'CTT': 1.53,
+    'GAA': 3.77,
+    'GAC': 2.35,
+    'GAG': 3.51,
+    'GAT': 2.93,
+    'GCA': 1.89,
+    'GCC': 2.35,
+    'GCG': 0.63,
+    'GCT': 2.21,
+    'GGA': 2.05,
+    'GGC': 1.95,
+    'GGG': 1.28,
+    'GGT': 1.32,
+    'GTA': 0.99,
+    'GTC': 1.33,
+    'GTG': 2.66,
+    'GTT': 1.49,
+    'TAA': 0.00,
+    'TAC': 1.48,
+    'TAG': 0.00,
+    'TAT': 1.61,
+    'TCA': 1.12,
+    'TCC': 1.30,
+    'TCG': 0.33,
+    'TCT': 1.43,
+    'TGA': 0.00,
+    'TGC': 0.92,
+    'TGG': 1.24,
+    'TGT': 1.03,
+    'TTA': 0.98,
+    'TTC': 1.85,
+    'TTG': 1.50,
+    'TTT': 2.16,
+}
+
 
 class Codon(object):
     """
@@ -106,13 +175,13 @@ class Codon(object):
         amino = None
         for base_list in itertools.product(*options):
             base_str = ''.join(base_list)
-            if base_str not in encodings.keys():
+            if base_str not in _encodings.keys():
                 return _UNKNOWN_AMINO
-            elif amino and amino != encodings[base_str]:
+            elif amino and amino != _encodings[base_str]:
                 # we've found a conflict
                 return _UNKNOWN_AMINO
             else:
-                amino = encodings[base_str]
+                amino = _encodings[base_str]
         return amino
 
     def encodes_same_amino(self, other):
@@ -133,3 +202,9 @@ class Codon(object):
             return self.bases == other.bases
 
         return self.get_amino() == other.get_amino()
+
+    def get_usage(self):
+        """
+        :return: the usage rate of this codon (genome-dependent)
+        """
+        return _usage[self.bases] if self.bases in _usage.keys() else 0

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ acid chain remains unaltered.
 
 from sequence import Sequence
 from wobble_cut_detector import WobbleCutDetector
+import codons
 import restriction_enzymes as enzymes
 
 # Must be properly left-aligned. (Use leading underscores to align first codon.)
@@ -19,12 +20,15 @@ if __name__ == '__main__':
     print('Original amino chain: \n\t{}'.format(aligned_seq.get_amino_string()))
     print()
     print('Checking sequence for potential cuts (leaving aminos unchanged)...')
+    print('(usage table: {})'.format(codons._usage_source))
     print()
 
     wobbler = WobbleCutDetector()
 
     for enzyme in enzymes.get_all_enzymes():
         wobble_cuts = wobbler.detect_cuts(aligned_seq, enzyme)
+        wobble_cuts.sort(key=lambda cut: (
+            cut.get_number_of_bases_modified(), cut.get_abs_usage_shift()))
         if len(wobble_cuts) > 0:
             print('possible cuts for {}:'.format(enzyme.name))
             for cut_edit in wobble_cuts:

--- a/src/test_codons.py
+++ b/src/test_codons.py
@@ -3,6 +3,20 @@ import codons
 import unittest
 
 
+class TestConfigs(unittest.TestCase):
+    def test_encoding_keys(self):
+        self.assertEqual(len(codons._encodings), 64)
+
+    def test_usage_keys(self):
+        self.assertEqual(len(codons._usage), 64)
+
+    def test_usage_sum(self):
+        max_diff = .005 * 64
+        usage_sum = sum(codons._usage.values())
+        self.assertLess(usage_sum, 100 + max_diff)
+        self.assertGreater(usage_sum, 100 - max_diff)
+
+
 class TestCodon(unittest.TestCase):
     def test_init_enforces_length(self):
         self.assertRaises(AssertionError, lambda: Codon(''))
@@ -69,6 +83,10 @@ class TestCodon(unittest.TestCase):
         self.assertTrue(Codon('__A').encodes_same_amino(Codon('__A')))
         # Note that '_' is *not* a wildcard. (TCN all map to the same amino)
         self.assertFalse(Codon('TC_').encodes_same_amino(Codon('TCA')))
+
+    def test_get_usage(self):
+        self.assertEqual(Codon('ACT').get_usage(), 1.42)
+        self.assertEqual(Codon('NBH').get_usage(), 0)
 
 
 if __name__ == '__main__':

--- a/src/test_sequence_edit.py
+++ b/src/test_sequence_edit.py
@@ -22,20 +22,35 @@ class TestSequenceEdit(unittest.TestCase):
         aligned_sequence = AlignedSequence('AAACCCGGGTTT')
         override_sequence = Sequence('AA')
         edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
-        self.assertEqual(str(edit), 'edit index: 4\tCCCGGG -> CCaaGG')
+        self.assertEqual(str(edit),
+                         'edit index: 4\tCCCGGG -> CCaaGG\tbases changed: 2\tabs usage shift: inf')
 
-    def test_number_of_bases_modified(self):
+    def test_get_number_of_bases_modified(self):
         aligned_sequence = AlignedSequence('AAACCCGGGTTT')
         override_sequence = Sequence('AA')
         edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
-        self.assertEqual(edit.number_of_bases_modified(), 2)
+        self.assertEqual(edit.get_number_of_bases_modified(), 2)
 
-    def test_number_of_amino_modified(self):
+    def test_get_number_of_amino_modified(self):
         aligned_sequence = AlignedSequence('AAACCCGGGTTT')
         override_sequence = Sequence('AA')
         edit = SequenceReplacementEdit(aligned_sequence, override_sequence, 5)
         # CCC and CCa both code P
-        self.assertEqual(edit.number_of_aminos_modified(), 1)
+        self.assertEqual(edit.get_number_of_aminos_modified(), 1)
+
+    def test_get_abs_usage_shift(self):
+        aat = AlignedSequence('aat')
+        aac = AlignedSequence('aac')
+        aataac = AlignedSequence('aataac')
+        aacaat = AlignedSequence('aacaat')
+        self.assertEqual(SequenceReplacementEdit(aat, aat, 0)
+                         .get_abs_usage_shift(), 0)
+        self.assertAlmostEqual(SequenceReplacementEdit(aat, aac, 0)
+                               .get_abs_usage_shift(), 0.29)
+        self.assertAlmostEqual(SequenceReplacementEdit(aac, aat, 0)
+                               .get_abs_usage_shift(), 0.29)
+        self.assertAlmostEqual(SequenceReplacementEdit(aacaat, aataac, 0)
+                               .get_abs_usage_shift(), 0.58)
 
 
 if __name__ == '__main__':

--- a/src/test_wobble_cut_detector.py
+++ b/src/test_wobble_cut_detector.py
@@ -50,7 +50,7 @@ class TestWobbleCutDetector(unittest.TestCase):
         enzyme = RestrictionEnzyme('enzyme_x', 'NNN')
         actual_cuts = WobbleCutDetector().detect_cuts(aligned, enzyme)
         expected_cut_count = len([
-            v for v in codons.encodings.values() if v == codons.encodings['AGT']
+            v for v in codons._encodings.values() if v == codons._encodings['AGT']
         ])
         self.assertEqual(len(actual_cuts), expected_cut_count)
 

--- a/src/wobble_cut_detector.py
+++ b/src/wobble_cut_detector.py
@@ -39,6 +39,6 @@ class WobbleCutDetector(object):
         edit_list = []
         for offset in range(len(aligned_sequence) - len(cut_seq) + 1):
             edit = SequenceReplacementEdit(aligned_sequence, cut_seq, offset)
-            if edit.number_of_aminos_modified() == 0:
+            if edit.get_number_of_aminos_modified() == 0:
                 edit_list.append(edit)
         return edit_list


### PR DESCRIPTION
to support a heuristic of wobble "quality"

Example of the new output format for edits (sorted by base changes, then usage shift):

possible cuts for AciI:
  edit index: 10	TAGAGG -> TAGcGG	bases changed: 1	abs usage shift: 0.05
  edit index: 22	TCAGCT -> TCcGCT	bases changed: 1	abs usage shift: 0.18
  edit index: 1	AGTGGC -> AGcGGC	bases changed: 1	abs usage shift: 0.21
  edit index: 31	AGCCGT -> AGCCGc	bases changed: 1	abs usage shift: 0.26
  edit index: 37	ACGGCA -> ACcGCA	bases changed: 1	abs usage shift: 1.06

Partially implements #4